### PR TITLE
Revert the '{{base}}' => '/' change as it was not needed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <!-- The href here is replaced with the docroot on the server
     -- It is only replaced once, so don't put the {{}} string anywhere else.
     -- It is not being parsed by handlebars; just a simple regexp replace -->
-  <base href="/">
+  <base href="{{base}}">
 
   <script src='bower_components/webcomponentsjs/webcomponents-lite.min.js'></script>
   <script src='fetch.js'></script>


### PR DESCRIPTION
Signed-off-by: James Ketrenos <james.p.ketrenos@intel.com>